### PR TITLE
fix crash when using `dpr` flag with only one of `w` and `h` [#5]

### DIFF
--- a/nginx-lua-mp4.lua
+++ b/nginx-lua-mp4.lua
@@ -115,10 +115,15 @@ if cachedFile == nil then
 
     -- process DPR
     if (flagValues['dpr'] ~= nil) then
-        log('w_h_dpr ' .. flagValues['width'] .. '_' .. flagValues['height'] .. '_' .. flagValues['dpr'])
-        flagValues['height'] = math.ceil(flagValues['height'] * flagValues['dpr'])
-        flagValues['width'] = math.ceil(flagValues['width'] * flagValues['dpr'])
-        log('w_h_dpr ' .. flagValues['width'] .. '_' .. flagValues['height'] .. '_' .. flagValues['dpr'])
+        log('w_h_dpr ' .. (flagValues['width'] or 'nil') .. '_' .. (flagValues['height'] or 'nil') .. '_' .. flagValues['dpr'])
+        if flagValues['height'] ~= nil then
+            flagValues['height'] = math.ceil(flagValues['height'] * flagValues['dpr'])
+        end
+        if flagValues['width'] ~= nil then
+            flagValues['width'] = math.ceil(flagValues['width'] * flagValues['dpr'])
+
+        end
+        log('w_h_dpr ' .. (flagValues['width'] or 'nil') .. '_' .. (flagValues['height'] or 'nil') .. '_' .. flagValues['dpr'])
     end
 
     if config.maxHeight ~= nil then


### PR DESCRIPTION
Closes #5 