### PR TITLE
make `identify` path configurable

### DIFF
--- a/command.lua
+++ b/command.lua
@@ -36,7 +36,7 @@ local function buildImageProcessingCommand(config, file, flags)
     end
 
     -- Create Canvas
-    command = command .. ' -size $(identify -ping -format "%wx%h" ' .. originalFilePath .. ')'
+    command = command .. ' -size $(' .. config.identify .. ' -ping -format "%wx%h" ' .. originalFilePath .. ')'
     if background == 'auto' then
       -- Get 2 dominant colors in format 'x000000-x000000'
       local cmd = config.magick .. ' ' .. originalFilePath ..

--- a/config.lua.example
+++ b/config.lua.example
@@ -12,6 +12,9 @@ config.ffmpeg = '/usr/local/bin/ffmpeg'
 -- `which magick`
 config.magick = '/usr/bin/magick'
 
+-- `which identify`
+config.identify = '/usr/bin/identify'
+
 -- where to save original and transcoded files (trailing slash required)
 config.mediaBaseFilepath = '/tmp/nginx/'
 


### PR DESCRIPTION
On some setups `identify` is not available in PATH, this adds `identify` to the config in the same way we have ffmpeg and magick paths there.